### PR TITLE
pickle.c -> note.c

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # PROJECT: note
-# LICENSE: Unlicense (see 'pickle.c' or 'LICENSE' file)
+# LICENSE: Unlicense (see 'note.c' or 'LICENSE' file)
 # SITE:    https://github.com/howerj/note
 #
 VERSION = 0x010000


### PR DESCRIPTION
I guess it should be this way, as `pickle.c` doesn't exist in the project. (Or maybe only `LICENSE` was supposed to be mentioned?)

Cool project by the way. I made something similar [in Shell](https://github.com/zdroid/dotfiles/blob/master/bin/note) a few years ago.